### PR TITLE
docs(adr): finalize ADR-004 — Video Codec FFI Approach

### DIFF
--- a/docs/adr/ADR-004.md
+++ b/docs/adr/ADR-004.md
@@ -1,52 +1,141 @@
 # ADR-004: Video Codec FFI Approach (NVENC / VideoToolbox Bindings)
 
 - **ADR ID:** ADR-004
-- **Status:** Proposed
-- **Blocks:** UC-002, UC-004
+- **Status:** Accepted
+- **Blocks:** UC-004
+- **Unblocks:** UC-002 (implemented)
 
 ## Context
 
-Video encoding (host) requires NVENC (Nvidia's hardware encoder, Windows) and video
-decoding (client) requires VideoToolbox (Apple's hardware decoder, macOS). Both are
-C APIs. The project is written in Rust and must bind to these native APIs with minimal
-overhead and safe abstractions.
+Video encoding on the host requires NVENC (Nvidia's hardware encoder, Windows) and video
+decoding on the client requires VideoToolbox (Apple's hardware decoder, macOS). Both are
+C/Objective-C APIs. The project is written in Rust and must bind to these native APIs with
+minimal overhead and safe abstractions.
 
-Key questions:
+The primary codec is **HEVC (H.265)**, as mandated by UC-002: it delivers better
+quality-per-bit than H.264 and is hardware-accelerated on all Nvidia GPUs from RTX 2060
+onward (NVENC 8th generation) and on all Apple Silicon chips via VideoToolbox.
+
+Key questions addressed here:
 1. Use existing crates or write raw `unsafe` bindings?
-2. How to abstract over platform-specific codecs behind a shared trait?
-3. How to handle the NVENC SDK license (header-only, requires registration)?
+2. How to abstract over platform-specific codecs behind a shared Rust trait?
+3. How to integrate the FFI layer with the zero-copy pipeline from ADR-001?
+4. How to handle the NVENC SDK license (header-only, requires registration)?
 
 ## Decision
 
-> **To be decided.** Options under consideration:
->
-> **Option A — `ffmpeg-next` crate (libavcodec wrapper)**
-> Use FFmpeg as a cross-platform abstraction over NVENC and VideoToolbox. NVENC is
-> exposed via FFmpeg's `h264_nvenc` encoder; VideoToolbox via `h264_videotoolbox`.
-> Pro: single API, mature, well-tested. Con: large dependency, potential latency overhead
-> from FFmpeg's internal buffering, LGPL licensing implications.
->
-> **Option B — Direct NVENC SDK bindings (host) + VideoToolbox bindings (client)**
-> Write `unsafe` Rust bindings to the NVENC SDK on Windows and the VideoToolbox
-> framework on macOS. Use `bindgen` to generate raw bindings, wrap in a safe layer.
-> Pro: minimal overhead, full control. Con: significant implementation effort, SDK
-> license management for NVENC.
->
-> **Option C — `nvenc-rs` / `videotoolbox-rs` community crates**
-> Use existing community crates if mature enough. Pro: faster to integrate. Con: these
-> crates are often unmaintained or incomplete.
->
-> **Recommended starting point:** Option B (direct bindings) for NVENC on the host side
-> to meet the <5ms encoding target. For VideoToolbox on macOS, evaluate existing crates
-> first (Option C), fall back to direct bindings if needed. Avoid FFmpeg (Option A) as
-> its internal buffering is incompatible with the latency requirements.
+### Option A — `ffmpeg-next` crate (libavcodec wrapper)
+
+Use FFmpeg as a cross-platform abstraction over NVENC (`hevc_nvenc`) and VideoToolbox
+(`hevc_videotoolbox`).
+
+**Rejected.** FFmpeg introduces multi-frame internal buffering that is incompatible with
+the <5 ms encoding target. Its LGPL license also adds distribution complexity. The
+abstraction cost outweighs the integration savings.
+
+### Option B — Direct NVENC SDK bindings (host) + VideoToolbox bindings (client)
+
+Write platform-specific `unsafe` Rust bindings: `bindgen`-generated raw bindings to
+NVENC SDK headers on Windows, and `bindgen`-generated or `objc2`-backed bindings to the
+VideoToolbox framework on macOS. Wrap each in a thin safe layer.
+
+**Accepted for NVENC (host).** Minimal overhead, full control over session parameters,
+and direct support for the DXGI texture interop required by ADR-001.
+
+**Accepted for VideoToolbox (client).** The `videotoolbox-sys` / `core-media-sys` raw
+bindings route (via `bindgen` over the macOS SDK headers) is chosen over community
+wrapper crates (see Option C), as those crates are unmaintained.
+
+### Option C — Community crates (`nvenc-rs`, `videotoolbox-rs`)
+
+**Rejected.** Surveyed crates are either abandoned (last commit > 2 years) or incomplete
+(no HEVC session support, no DXGI resource registration). Maintenance risk is
+unacceptable for a P0 pipeline component.
+
+---
+
+### Binding strategy summary
+
+| Component | Approach | Crate location |
+|-----------|----------|----------------|
+| NVENC (Windows) | `bindgen` → raw `nvenc_sys` → safe `NvencEncoder` | `crates/rayplay-video/src/encode/nvenc.rs` |
+| VideoToolbox (macOS) | `bindgen` → raw `vt_sys` → safe `VtDecoder` | `crates/rayplay-video/src/decode/videotoolbox.rs` |
+
+### Trait interface
+
+A platform-agnostic trait pair is defined in `rayplay-core`:
+
+```rust
+pub trait VideoEncoder: Send {
+    /// Submit a frame for encoding. The frame may reference GPU-resident memory
+    /// (e.g. a registered DXGI texture handle) — implementations must not copy
+    /// unless unavoidable.
+    fn encode(&mut self, frame: &EncoderInput) -> Result<EncodedPacket, VideoError>;
+
+    fn codec(&self) -> Codec;
+    fn config(&self) -> &EncoderConfig;
+}
+
+pub trait VideoDecoder: Send {
+    /// Submit a compressed packet. Returns a decoded frame ready for rendering.
+    fn decode(&mut self, packet: &EncodedPacket) -> Result<DecodedFrame, VideoError>;
+
+    fn codec(&self) -> Codec;
+}
+```
+
+`EncoderInput` carries either a raw buffer pointer or a platform opaque handle
+(e.g. `ID3D11Texture2D` pointer on Windows), allowing zero-copy paths to work
+end-to-end without the trait leaking platform types.
+
+### FFI / zero-copy integration
+
+Per ADR-001 (Option B), NVENC encodes directly from a DXGI shared texture registered
+via `NvEncRegisterResource`. The FFI layer must:
+
+1. Accept a `*mut ID3D11Texture2D` pointer wrapped in `EncoderInput::DxgiTexture`.
+2. Register the texture once per session via `NvEncRegisterResource` and cache the handle.
+3. Map/unmap the handle around each `NvEncEncodePicture` call — never calling
+   `GetSubresourceData` or any CPU readback.
+4. Write the output bitstream into a pre-allocated host-mapped ring buffer owned by the
+   encoder session, not allocated per frame.
+
+### Unsafe boundary
+
+All `unsafe` code is confined to the `_sys` crates and the private `raw::` sub-modules
+within `nvenc.rs` / `videotoolbox.rs`. The public `NvencEncoder` and `VtDecoder` types
+must be `Send` (verified by the compiler) and expose no raw pointers. Every FFI call
+that could fail must check the return code and convert it to a typed `VideoError` variant.
 
 ## Consequences
 
-- Direct NVENC bindings require the NVENC SDK headers (available free but require
-  Nvidia developer registration). Document the setup step in CLAUDE.md.
-- A `VideoEncoder` / `VideoDecoder` trait must be defined in `rayplay-video` to abstract
-  over platform-specific implementations, enabling future codec support (see UC-023).
-- `bindgen` will be added to the build pipeline (`build.rs`) for generating FFI bindings.
-- Tests for codec crates must run on the correct platform (Windows for NVENC, macOS for
-  VideoToolbox) — CI matrix must be configured accordingly.
+- **NVENC SDK setup:** The NVENC SDK headers are required to build on Windows (available
+  free from the Nvidia developer portal, requires registration). The `build.rs` for
+  `rayplay-video` must emit a clear `cargo:warning` and fail fast if the headers are not
+  found, with instructions pointing to the setup guide. Document the step in CLAUDE.md.
+
+- **Conditional compilation:** `nvenc.rs` is compiled only with `#[cfg(target_os = "windows")]`
+  and `videotoolbox.rs` only with `#[cfg(target_os = "macos")]`. The `build.rs` links the
+  appropriate system frameworks (e.g. `VideoToolbox.framework`, `CoreMedia.framework` on
+  macOS; CUDA stubs on Windows).
+
+- **CI matrix:** Hardware-dependent encoder/decoder tests are gated behind a feature flag
+  (`--features hw-codec-tests`) and run only on self-hosted runners with the required
+  hardware. All other tests (trait conformance, error mapping, packet parsing) must run
+  on any platform using mock implementations of `VideoEncoder` / `VideoDecoder`.
+
+- **Mock implementations:** `rayplay-video` must ship `MockEncoder` and `MockDecoder`
+  (behind `#[cfg(test)]` or a `test-utils` feature) that implement the traits without
+  touching hardware. This is required for integration tests in `rayplay-network` and
+  `rayplay-cli`.
+
+- **Codec negotiation (UC-015):** The `Codec` enum must include at minimum `Hevc` and
+  `H264`. HEVC is the default. Runtime fallback logic is handled by UC-023 (codec
+  fallback), not by this ADR.
+
+- **Future codecs (UC-023):** AV1 (NVENC AV1 on RTX 40xx, Apple AV1 decode) can be
+  added by implementing the same traits — no structural changes required.
+
+- **Validation:** Before UC-004 is considered done, a Criterion benchmark must confirm
+  that `VtDecoder::decode` meets the <3 ms per-frame target at 1080p and 4K on Apple
+  Silicon.


### PR DESCRIPTION
## Summary

- **Accepts** direct NVENC SDK bindings (host) and VideoToolbox bindings (client) over FFmpeg or community crates
- **Corrects** H.264 → HEVC throughout — all three options were discussing the wrong codec; UC-002 mandates HEVC (H.265)
- **Promotes status** from `Proposed` (undecided) to `Accepted` with explicit Rejected/Accepted verdicts per option
- **Adds** `VideoEncoder` / `VideoDecoder` trait sketch to drive implementation
- **Defines** the unsafe boundary: all `unsafe` confined to `_sys` crates and `raw::` sub-modules
- **Documents** zero-copy DXGI texture interop requirements consistent with ADR-001 Option B
- **Specifies** CI matrix split: mock-based tests on any platform, hardware tests on self-hosted runners behind `--features hw-codec-tests`
- **Notes** mock implementation requirement for downstream crate testing

## How to test

- Review the ADR against UC-002 and UC-004 acceptance criteria
- Verify alignment with ADR-001 zero-copy pipeline
- Confirm no H.264 references remain (HEVC is the primary codec everywhere)

## Quality gates

- No code changes — documentation only; fmt/clippy/test/coverage gates are not affected