### PR TITLE
feat(cli): add hostname support to rayview --host argument

### DIFF
--- a/crates/rayplay-cli/src/client/config.rs
+++ b/crates/rayplay-cli/src/client/config.rs
@@ -13,7 +13,7 @@ use clap::Parser;
     long_about = "Connect to a RayPlay host and render the streamed display."
 )]
 pub struct ClientArgs {
-    /// IP address of the host to connect to (e.g., 192.168.1.10).
+    /// IP address or hostname of the host to connect to (e.g., 192.168.1.10 or my-host.local).
     pub host: String,
 
     /// UDP port the host is listening on.
@@ -56,22 +56,38 @@ fn default_cert_path() -> PathBuf {
         .join(".config/rayview/server.der")
 }
 
+/// Resolves a host string (IP or hostname) and port into a [`SocketAddr`].
+///
+/// Tries a direct IP parse first to avoid a DNS lookup, then falls back to
+/// DNS resolution via [`std::net::ToSocketAddrs`].
+fn resolve_host(host: &str, port: u16) -> Result<SocketAddr> {
+    use std::net::ToSocketAddrs;
+
+    // Fast path: try direct IP parse first (avoids DNS lookup)
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        return Ok(SocketAddr::new(ip, port));
+    }
+
+    // Fallback: DNS resolution
+    format!("{host}:{port}")
+        .to_socket_addrs()
+        .with_context(|| format!("failed to resolve host '{host}'"))?
+        .next()
+        .with_context(|| format!("no addresses found for host '{host}'"))
+}
+
 impl ClientConfig {
     /// Builds a [`ClientConfig`] from the parsed CLI arguments.
     ///
     /// # Errors
     ///
-    /// Returns an error if `args.host` is not a valid IP address.
+    /// Returns an error if `args.host` cannot be parsed as an IP address or
+    /// resolved via DNS.
     pub fn from_args(args: &ClientArgs) -> Result<Self> {
-        let host_ip: std::net::IpAddr = args.host.parse().with_context(|| {
-            format!(
-                "invalid host address '{}': expected an IP address (e.g. 192.168.1.10)",
-                args.host
-            )
-        })?;
+        let server_addr = resolve_host(&args.host, args.port)?;
         let cert_path = args.cert.clone().unwrap_or_else(default_cert_path);
         Ok(Self {
-            server_addr: SocketAddr::new(host_ip, args.port),
+            server_addr,
             cert_path,
             width: args.width,
             height: args.height,
@@ -157,9 +173,31 @@ mod tests {
 
     #[test]
     fn test_from_args_invalid_host_returns_descriptive_error() {
+        // "not-an-ip" is not a valid hostname either, DNS will fail
         let err = ClientConfig::from_args(&dummy_args("not-an-ip")).unwrap_err();
-        assert!(err.to_string().contains("invalid host address"));
+        assert!(err.to_string().contains("failed to resolve host"));
         assert!(err.to_string().contains("not-an-ip"));
+    }
+
+    #[test]
+    fn test_from_args_localhost_resolves_to_socket_addr() {
+        let config = ClientConfig::from_args(&dummy_args("localhost")).unwrap();
+        assert_eq!(config.server_addr.port(), 5000);
+    }
+
+    #[test]
+    fn test_from_args_unresolvable_hostname_returns_error() {
+        let err =
+            ClientConfig::from_args(&dummy_args("this-host-does-not-exist-xyz-12345.invalid"))
+                .unwrap_err();
+        assert!(err.to_string().contains("failed to resolve host"));
+    }
+
+    #[test]
+    fn test_from_args_ipv6_builds_socket_addr() {
+        let config = ClientConfig::from_args(&dummy_args("::1")).unwrap();
+        assert_eq!(config.server_addr.ip().to_string(), "::1");
+        assert_eq!(config.server_addr.port(), 5000);
     }
 
     #[test]
@@ -172,6 +210,23 @@ mod tests {
         assert_eq!(config.width, 1920);
         assert_eq!(config.height, 1080);
         assert_eq!(config.cert_path, std::path::Path::new("/path/to/cert.der"));
+    }
+
+    #[test]
+    fn test_default_cert_path_without_home_falls_back_to_dot() {
+        use std::sync::Mutex;
+        static LOCK: Mutex<()> = Mutex::new(());
+        let _guard = LOCK.lock().unwrap();
+
+        let orig = std::env::var_os("HOME");
+        // SAFETY: single-threaded via mutex
+        unsafe { std::env::remove_var("HOME") };
+        let path = default_cert_path();
+        match orig {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => {}
+        }
+        assert_eq!(path, std::path::Path::new("./.config/rayview/server.der"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `resolve_host` helper that fast-paths IP addresses and falls back to DNS via `std::net::ToSocketAddrs`
- Updates `from_args` to use `resolve_host` — users can now pass `my-host.local`, `gaming-pc`, etc.
- Updates error message to reflect DNS resolution context
- Adds 4 new tests: `localhost` resolution, unresolvable hostname, IPv6 fast-path, `HOME`-unset fallback

Closes #52

## Test plan

- [ ] `cargo test --workspace` — all tests pass
- [ ] `cargo clippy --workspace -- -W clippy::pedantic` — zero warnings
- [ ] `cargo fmt --all` — no formatting changes
- [ ] `cargo make coverage-ci` — coverage unchanged from baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)