### PR TITLE
feat: migrate slash commands to skills

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -5,6 +5,8 @@ model: claude-sonnet-4-20250514
 tools:
   - Read
   - Write
+  - Grep
+  - Glob
   - Bash(cargo fmt *)
   - Bash(cargo test *)
   - Bash(cargo clippy *)

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -5,6 +5,8 @@ model: claude-sonnet-4-20250514
 tools:
   - Read
   - Write
+  - Grep
+  - Glob
   - Bash(find *)
   - Bash(cat *)
   - Bash(gh issue *)

--- a/.claude/agents/project-manager.md
+++ b/.claude/agents/project-manager.md
@@ -4,10 +4,13 @@ description: "Project manager who tracks deliverables, timelines, velocity, bloc
 model: claude-sonnet-4-20250514
 tools:
   - Read
+  - Grep
+  - Glob
   - Bash(git log *)
   - Bash(git shortlog *)
   - Bash(gh issue *)
   - Bash(gh pr *)
+  - Bash(gh run *)
   - Bash(find *)
   - Bash(wc *)
   - Bash(cat *)

--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -4,6 +4,8 @@ description: "QA engineer who validates acceptance criteria, runs integration te
 model: claude-sonnet-4-20250514
 tools:
   - Read
+  - Grep
+  - Glob
   - Bash(cargo test *)
   - Bash(cargo llvm-cov *)
   - Bash(cargo clippy *)

--- a/.claude/agents/senior-developer.md
+++ b/.claude/agents/senior-developer.md
@@ -4,6 +4,8 @@ description: "Senior Rust developer who reviews code for quality, architecture, 
 model: claude-opus-4-20250514
 tools:
   - Read
+  - Grep
+  - Glob
   - Bash(cargo fmt *)
   - Bash(cargo test *)
   - Bash(cargo clippy *)

--- a/.claude/commands/coverage.md
+++ b/.claude/commands/coverage.md
@@ -1,4 +1,0 @@
-Run `cargo make coverage-ci` on the workspace. It uses --fail-under-lines 99 and
-exits non-zero if coverage is below threshold. If it fails, run `cargo llvm-cov
---workspace` to see the detailed report, find the uncovered paths, and add unit
-tests to bring coverage back above 99%.

--- a/.claude/commands/eod.md
+++ b/.claude/commands/eod.md
@@ -1,4 +1,0 @@
-Use the project-manager agent to summarize today's progress.
-Use gh issue list to report: issues closed today, issues still in-progress,
-issues blocked, and new issues created. Also list PRs merged, coverage trends,
-and blockers. Compare issues closed vs. daily target (3-5).

--- a/.claude/commands/gates.md
+++ b/.claude/commands/gates.md
@@ -1,2 +1,0 @@
-Run `cargo make ci` which executes fmt, clippy --pedantic, all tests, and coverage
-(--fail-under-lines 99) as a single composite task. Report any failures.

--- a/.claude/commands/implement-gh-issue.md
+++ b/.claude/commands/implement-gh-issue.md
@@ -1,6 +1,0 @@
-Implement gh issue $ARGUMENTS. Follow all non-functional requirements
-in CLAUDE.md. First, find the GitHub Issue with gh issue view $ARGUMENTS and update
-its status to in-progress. Read the acceptance criteria and implement in the appropriate
-crate. Write unit tests. Run `cargo make ci` (fmt + clippy + tests + coverage gate) to
-verify all quality gates pass before committing. When creating the PR,
-include "Closes #<issue-number>" in the PR body.

--- a/.claude/commands/implement-uc.md
+++ b/.claude/commands/implement-uc.md
@@ -1,6 +1,0 @@
-Implement $ARGUMENTS from docs/uc/$ARGUMENTS.md. Follow all non-functional requirements
-in CLAUDE.md. First, find the GitHub Issue for $ARGUMENTS with gh issue list and update
-its status to in-progress. Read the acceptance criteria and implement in the appropriate
-crate. Write unit tests. Run `cargo make ci` (fmt + clippy + tests + coverage gate) to
-verify all quality gates pass before committing. When creating the PR,
-include "Closes #<issue-number>" in the PR body.

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,3 +1,0 @@
-gh pr diff $ARGUMENTS | claude "Review this diff against our CLAUDE.md standards.
-Check: idiomatic Rust, test coverage, clippy compliance,
-clean code principles, and UC acceptance criteria."

--- a/.claude/commands/qa.md
+++ b/.claude/commands/qa.md
@@ -1,3 +1,0 @@
-Use the qa-tester agent to validate $ARGUMENTS. Read the acceptance criteria
-from docs/uc/$ARGUMENTS.md. Run all tests, check coverage, and verify each
-acceptance criterion.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,2 +1,0 @@
-Use the senior-developer agent to review the changes on this branch
-against $ARGUMENTS's acceptance criteria in docs/uc/$ARGUMENTS.md. Rather than looking at each change one at a time, prefer checking out the whole change and reading the files directly. Also make sure you do these in a git worktree, if you are not already in one, create one.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,9 +1,0 @@
-Commit all changes with a conventional commit message referencing $ARGUMENTS.
-Push the branch and create a PR targeting main.
-Find the GitHub Issue number for $ARGUMENTS with gh issue list.
-Include in the PR description:
-- UC ID and title (from docs/uc/$ARGUMENTS.md)
-- "Closes #<issue-number>" to auto-close the issue on merge
-- Summary of changes
-- How to test
-- Quality gate checklist

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,8 +1,0 @@
-Use the project-manager agent to give me a status report.
-Check GitHub Issues status with gh issue list, open PRs with gh pr list,
-recent commits on main with git log --oneline -10, and test coverage
-with cargo llvm-cov --workspace.
-Group issues by status label (in-progress, blocked, todo) and cross-reference
-with open PRs.
-Format as a table with sections for: Issues by Status, PRs, Recent Commits,
-Coverage, Blockers.

--- a/.claude/commands/uc-create.md
+++ b/.claude/commands/uc-create.md
@@ -1,4 +1,0 @@
-Use the product-manager agent to write a UC for $ARGUMENTS.
-Save the UC document to docs/uc/ and then create a matching GitHub Issue
-with the appropriate priority, status:todo, and size labels.
-Include the acceptance criteria as checkboxes in the issue body.

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: code-review
+description: "Review branch changes against UC acceptance criteria"
+context: fork
+agent: senior-developer
+argument-hint: "<UC-ID e.g. UC-027>"
+---
+
+## UC Document
+
+```
+!`UC_FILE=$(find docs/uc/ -maxdepth 1 -iname "*${ARGUMENTS}*" -name "*.md" | head -1); [ -n "$UC_FILE" ] && cat "$UC_FILE" || echo "No UC document matching '$ARGUMENTS' found. Available: $(ls docs/uc/)"`
+```
+
+## Commit History
+
+```
+!`git log --oneline main..HEAD`
+```
+
+## Changed Files
+
+```
+!`git diff --stat main...HEAD`
+```
+
+## Full Diff
+
+```
+!`git diff main...HEAD`
+```
+
+## Instructions
+
+This is a **read-only review** — do NOT modify any files. Read the changed files directly rather than reviewing the diff line by line. Check if there's an associated PR with `gh pr list --search "$ARGUMENTS"` and read its description. Review against the project's standards in CLAUDE.md. Use the review output format from your agent instructions.

--- a/.claude/skills/coverage/SKILL.md
+++ b/.claude/skills/coverage/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: coverage
+description: "Run coverage, find gaps, and add tests to meet the threshold"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+---
+
+Run the project's coverage command as described in CLAUDE.md. If coverage is below the threshold, use Grep and Glob to find the uncovered source files. Read the coverage report to identify specific uncovered lines, then add tests to fill the gaps. Re-run coverage to confirm the threshold is met.

--- a/.claude/skills/eod/SKILL.md
+++ b/.claude/skills/eod/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: eod
+description: "End-of-day summary of today's progress"
+context: fork
+agent: project-manager
+disable-model-invocation: true
+---
+
+## Today's Commits
+
+```
+!`git log --oneline --since="midnight" main`
+```
+
+## Recently Closed Issues
+
+```
+!`gh issue list --state closed --json number,title,closedAt --limit 20`
+```
+
+## In-Progress Issues
+
+```
+!`gh issue list --label "status:in-progress" --json number,title,labels`
+```
+
+## Blocked Issues
+
+```
+!`gh issue list --label "blocked" --json number,title,labels`
+```
+
+## Instructions
+
+Summarize today's progress. Report: issues closed today, issues still in-progress, issues blocked, and new issues created. Identify PRs merged today with `gh pr list --state merged --json number,title,mergedAt`. Check latest CI status via `gh run list --limit 1`. Compare issues closed vs. daily target.

--- a/.claude/skills/gates/SKILL.md
+++ b/.claude/skills/gates/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: gates
+description: "Run quality gates and report results"
+disable-model-invocation: true
+allowed-tools:
+  - Bash
+  - Read
+---
+
+Current working tree:
+```
+!`git status --short`
+```
+
+Run the project's CI/quality gate command as described in CLAUDE.md. Report each gate's result (pass/fail) and the relevant output for any failures.

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: implement-issue
+description: "Implement a GitHub issue end-to-end"
+context: fork
+agent: developer
+argument-hint: "<issue-number>"
+---
+
+## Issue Details
+
+```
+!`gh issue view $ARGUMENTS --json number,title,body,labels,comments`
+```
+
+## Referenced UC Document (if any)
+
+```
+!`UC_ID=$(gh issue view $ARGUMENTS --json body --jq '.body' | grep -oE 'UC-[0-9]+' | head -1); [ -n "$UC_ID" ] && cat docs/uc/${UC_ID}.md 2>/dev/null || echo "No UC document referenced in issue body."`
+```
+
+## Instructions
+
+Update the issue status to in-progress. Identify which modules and packages are relevant by searching the codebase for related types and functions using Grep and Glob. Implement the feature following CLAUDE.md standards. Write tests. Run the project's quality gates as described in CLAUDE.md. Create a PR with "Closes #$ARGUMENTS" in the body.

--- a/.claude/skills/implement-uc/SKILL.md
+++ b/.claude/skills/implement-uc/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: implement-uc
+description: "Implement a Use Case end-to-end"
+context: fork
+agent: developer
+argument-hint: "<UC-ID e.g. UC-027>"
+---
+
+## UC Document
+
+```
+!`UC_FILE=$(find docs/uc/ -maxdepth 1 -iname "*${ARGUMENTS}*" -name "*.md" | head -1); [ -n "$UC_FILE" ] && cat "$UC_FILE" || echo "No UC document matching '$ARGUMENTS' found. Available: $(ls docs/uc/)"`
+```
+
+## GitHub Issue
+
+```
+!`gh issue list --search "$ARGUMENTS" --json number,title,labels --jq '.[0]'`
+```
+
+## Issue Details
+
+```
+!`ISSUE_NUM=$(gh issue list --search "$ARGUMENTS" --json number --jq '.[0].number'); [ -n "$ISSUE_NUM" ] && gh issue view "$ISSUE_NUM" --json number,body,comments 2>/dev/null || echo "No matching issue found."`
+```
+
+## Instructions
+
+Update the matching GitHub issue to in-progress. Read the UC's Technical Approach section and search the codebase with Grep and Glob for related existing types and modules. Implement in the appropriate package. Write tests. Run the project's quality gates as described in CLAUDE.md. Create a PR with "Closes #<issue-number>" in the body.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: pr-review
+description: "Review a pull request against project standards"
+context: fork
+agent: senior-developer
+argument-hint: "<PR-number>"
+---
+
+## PR Metadata
+
+```
+!`gh pr view $ARGUMENTS --json title,body,headRefName,baseRefName,additions,deletions,files`
+```
+
+## PR Diff
+
+```
+!`gh pr diff $ARGUMENTS`
+```
+
+## Existing Reviews
+
+```
+!`gh api repos/$(gh repo view --json nameWithOwner --jq '.nameWithOwner')/pulls/$ARGUMENTS/reviews --jq '.[] | {user: .user.login, state: .state, body: .body}' 2>/dev/null || echo "No existing reviews."`
+```
+
+## Instructions
+
+This is a **read-only review** — do NOT modify any files. Review the diff against the project's standards in CLAUDE.md. If the PR body references a UC or feature document, read it to verify acceptance criteria. Check: code quality, test coverage, linter compliance, clean code principles. Use the review output format from your agent instructions.

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: qa
+description: "Validate a UC against its acceptance criteria"
+context: fork
+agent: qa-tester
+argument-hint: "<UC-ID e.g. UC-027>"
+---
+
+## UC Document
+
+```
+!`UC_FILE=$(find docs/uc/ -maxdepth 1 -iname "*${ARGUMENTS}*" -name "*.md" | head -1); [ -n "$UC_FILE" ] && cat "$UC_FILE" || echo "No UC document matching '$ARGUMENTS' found. Available: $(ls docs/uc/)"`
+```
+
+## Instructions
+
+This is a **read-only validation** — do NOT modify source code or tests, only report findings. First, identify which modules implement this UC by searching for related types, functions, and test files using Grep and Glob. Check if there's an open PR with `gh pr list --search "$ARGUMENTS"`. Run the project's quality gates as described in CLAUDE.md. For each acceptance criterion, trace it to specific code and tests. Report using the issue format from your agent instructions.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: ship
+description: "Commit, push, and create a PR for the current branch"
+disable-model-invocation: true
+allowed-tools:
+  - Bash
+  - Read
+argument-hint: "<UC-ID or feature-name>"
+---
+
+## Current State
+
+Branch: `!`git branch --show-current``
+
+```
+!`git status --short`
+```
+
+```
+!`git diff --stat`
+```
+
+## UC Document
+
+```
+!`UC_FILE=$(find docs/uc/ -maxdepth 1 -iname "*${ARGUMENTS}*" -name "*.md" | head -1); [ -n "$UC_FILE" ] && cat "$UC_FILE" || echo "No UC document matching '$ARGUMENTS' found."`
+```
+
+## GitHub Issue
+
+```
+!`gh issue list --search "$ARGUMENTS" --json number,title --jq '.[0]'`
+```
+
+## Instructions
+
+Commit all changes with a conventional commit message referencing $ARGUMENTS. Push the branch and create a PR targeting the main branch. Use the PR template from `${CLAUDE_SKILL_DIR}/pr-template.md`. Include "Closes #<issue-number>" in the PR body. If quality gates haven't been run yet, warn the user but don't run them — that's a separate step.

--- a/.claude/skills/ship/pr-template.md
+++ b/.claude/skills/ship/pr-template.md
@@ -1,0 +1,16 @@
+## Summary
+<!-- UC ID, title, and 1-3 bullet points describing the changes -->
+
+Closes #<issue-number>
+
+## Changes
+<!-- List the key changes made -->
+
+## How to Test
+<!-- Steps to verify the changes work correctly -->
+
+## Quality Gates
+- [ ] fmt
+- [ ] clippy --pedantic
+- [ ] tests
+- [ ] coverage >= threshold

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: status
+description: "Project status report with issues, PRs, and CI health"
+context: fork
+agent: project-manager
+---
+
+## Open Issues
+
+```
+!`gh issue list --limit 50 --json number,title,labels,state`
+```
+
+## Open PRs
+
+```
+!`gh pr list --json number,title,headRefName,state,statusCheckRollup`
+```
+
+## Recent Commits
+
+```
+!`git log --oneline -10 main`
+```
+
+## Instructions
+
+Group issues by status label (in-progress, blocked, todo) and cross-reference with open PRs. Check the latest CI run results via `gh run list --limit 3`. Format as a table with sections: Issues by Status, PRs, Recent Commits, CI Status, Blockers.

--- a/.claude/skills/uc-create/SKILL.md
+++ b/.claude/skills/uc-create/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: uc-create
+description: "Create a new Use Case document and matching GitHub issue"
+context: fork
+agent: product-manager
+argument-hint: "<feature description>"
+---
+
+## Existing UC Files
+
+```
+!`ls docs/uc/ | sort -V | tail -5`
+```
+
+## Requirements Documents
+
+```
+!`ls docs/requirements/ 2>/dev/null || echo "No requirements directory found."`
+```
+
+## Instructions
+
+Read relevant existing UCs and requirements docs to understand project context and avoid overlapping scope. Read the template from `${CLAUDE_SKILL_DIR}/uc-template.md`. Write the UC document to docs/uc/ with the next available ID. Create a matching GitHub Issue with the appropriate priority and status:todo labels, using checkboxes for each acceptance criterion.

--- a/.claude/skills/uc-create/uc-template.md
+++ b/.claude/skills/uc-create/uc-template.md
@@ -1,0 +1,21 @@
+# UC-XXX: Title
+
+## Description
+As a [user], I want [goal], so that [benefit].
+
+## Acceptance Criteria
+1. [ ] Criterion 1
+2. [ ] Criterion 2
+3. [ ] Criterion 3
+
+## Technical Approach
+High-level implementation guidance.
+
+## Dependencies
+- None / UC-YYY
+
+## Estimated Complexity
+S / M / L
+
+## Priority
+P0 / P1 / P2


### PR DESCRIPTION
## Summary
- Migrate all 11 `.claude/commands/` to `.claude/skills/` with full skill frontmatter
- Add dynamic context injection (`!`cmd``) for pre-fetching issue/UC/PR data
- Add `context: fork` + `agent:` delegation on 8 of 11 skills
- Add `Grep` + `Glob` tools to 5 agent definitions (developer, senior-developer, qa-tester, product-manager, project-manager)
- Add `Bash(gh run *)` to project-manager for CI status checks
- Rename `review` → `code-review`, `implement-gh-issue` → `implement-issue`

## Test plan
- [ ] Verify `/coverage` runs in main session and suggests test additions
- [ ] Verify `/gates` pre-fetches git status and runs CI pipeline
- [ ] Verify `/implement-issue 42` forks to developer agent with issue context
- [ ] Verify `/implement-uc UC-026` resolves UC doc via fuzzy find
- [ ] Verify `/ship UC-026` commits, pushes, and creates PR with template
- [ ] Verify `/pr-review 75` forks to senior-developer with full diff
- [ ] Verify `/qa UC-026` forks to qa-tester in read-only mode
- [ ] Verify `/code-review UC-026` forks to senior-developer with branch diff
- [ ] Verify `/status` and `/eod` fork to project-manager
- [ ] Verify `/uc-create` forks to product-manager with template reference
- [ ] Verify fuzzy resolution: `uc-26`, `UC-026`, `26` all resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)