### PR TITLE
fix(network): send pair intent before PIN prompt to prevent deadlock

### DIFF
--- a/crates/rayplay-cli/src/client/connect.rs
+++ b/crates/rayplay-cli/src/client/connect.rs
@@ -152,7 +152,12 @@ pub async fn connect(
             .await
             .map_err(|e| anyhow::anyhow!("failed to open control channel: {e}"))?;
 
-        // Prompt user for PIN
+        // Tell the host we want to pair so it generates and displays the PIN.
+        rayplay_network::client_send_pair_intent(&mut control)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to send pair intent: {e}"))?;
+
+        // Now prompt the user — the host is already showing the PIN.
         tracing::info!("Enter the 6-digit PIN shown on the host:");
         let mut pin = String::new();
         std::io::stdin()

--- a/crates/rayplay-network/src/lib.rs
+++ b/crates/rayplay-network/src/lib.rs
@@ -30,7 +30,10 @@ pub use keepalive::{
     DEFAULT_KEEPALIVE_INTERVAL, DEFAULT_KEEPALIVE_TIMEOUT, run_keepalive_responder,
     run_keepalive_sender,
 };
-pub use pairing::{client_auth_response, client_pairing, host_auth_challenge, host_pairing};
+pub use pairing::{
+    client_auth_response, client_pairing, client_send_pair_intent, host_auth_challenge,
+    host_pairing,
+};
 pub use reassembler::VideoReassembler;
 pub use transport::{QuicListener, QuicVideoTransport};
 pub use wire::{

--- a/crates/rayplay-network/src/pairing.rs
+++ b/crates/rayplay-network/src/pairing.rs
@@ -130,7 +130,27 @@ pub async fn host_pairing(
     Ok(trusted_client)
 }
 
+/// Sends `ClientHello(Pair)` to declare pairing intent.
+///
+/// Call this before prompting for the PIN so the host can generate and
+/// display it.  Follow up with [`client_pairing`] once the user has
+/// entered the PIN.
+///
+/// # Errors
+///
+/// Returns a [`SessionError`] if the message cannot be sent.
+pub async fn client_send_pair_intent(
+    control: &mut ControlChannel,
+) -> Result<(), SessionError> {
+    control
+        .send_msg(&ControlMessage::ClientHello(ClientIntent::Pair))
+        .await
+}
+
 /// Runs the client side of the SPAKE2 pairing exchange.
+///
+/// The caller must have already sent `ClientHello(Pair)` via
+/// [`client_send_pair_intent`] before calling this function.
 ///
 /// Generates an ed25519 key pair, executes the SPAKE2 protocol with the given
 /// `pin`, and returns the signing key on success.
@@ -143,12 +163,7 @@ pub async fn client_pairing(
     control: &mut ControlChannel,
     pin: &str,
 ) -> Result<SigningKey, SessionError> {
-    // 1. Send ClientHello to declare pairing intent
-    control
-        .send_msg(&ControlMessage::ClientHello(ClientIntent::Pair))
-        .await?;
-
-    // 2. Generate ed25519 key pair
+    // 1. Generate ed25519 key pair
     let signing_key = SigningKey::generate(&mut rand_core::OsRng);
     let verifying_key = signing_key.verifying_key();
 

--- a/crates/rayplay-network/src/pairing/tests.rs
+++ b/crates/rayplay-network/src/pairing/tests.rs
@@ -30,6 +30,15 @@ async fn control_pair() -> (ControlChannel, ControlChannel) {
     (client_ctrl, server_ctrl)
 }
 
+/// Sends `ClientHello(Pair)` then runs `client_pairing`, mirroring the CLI flow.
+async fn full_client_pairing(
+    control: &mut ControlChannel,
+    pin: &str,
+) -> Result<SigningKey, SessionError> {
+    client_send_pair_intent(control).await?;
+    client_pairing(control, pin).await
+}
+
 /// Consumes the `ClientHello` message and dispatches to the appropriate
 /// host-side function (pairing or auth challenge), mirroring the CLI glue.
 async fn host_dispatch(
@@ -61,7 +70,7 @@ async fn test_pairing_flow_success() {
     let mut trust_db = TrustDatabase::new();
 
     let (client_result, server_result) = tokio::join!(
-        client_pairing(&mut client_ctrl, pin),
+        full_client_pairing(&mut client_ctrl, pin),
         host_dispatch(&mut server_ctrl, pin, &mut trust_db, "test-client"),
     );
 
@@ -81,7 +90,7 @@ async fn test_pairing_flow_pin_mismatch() {
     let mut trust_db = TrustDatabase::new();
 
     let (client_result, server_result) = tokio::join!(
-        client_pairing(&mut client_ctrl, "123456"),
+        full_client_pairing(&mut client_ctrl, "123456"),
         host_dispatch(&mut server_ctrl, "654321", &mut trust_db, "test-client"),
     );
 
@@ -100,7 +109,7 @@ async fn test_auth_flow_success() {
     // First, pair to get a trusted key
     let pin = "123456";
     let (client_key, _) = tokio::join!(
-        client_pairing(&mut client_ctrl, pin),
+        full_client_pairing(&mut client_ctrl, pin),
         host_dispatch(&mut server_ctrl, pin, &mut trust_db, "test-device"),
     );
     let key = client_key.unwrap();
@@ -258,13 +267,9 @@ async fn test_client_pairing_connection_closed_during_wait() {
     // Server closes connection before sending response
     let client_task = tokio::spawn(async move { client_pairing(&mut client_ctrl, "123456").await });
 
-    // Send ClientHello, receive, then close
-    let hello = server_ctrl.recv_msg("test").await.unwrap();
-    if let ControlMessage::ClientHello(ClientIntent::Pair) = hello {
-        // Receive PairingRequest but don't respond
-        let _request = server_ctrl.recv_msg("test").await.unwrap();
-        drop(server_ctrl);
-    }
+    // Receive PairingRequest but don't respond, then close
+    let _request = server_ctrl.recv_msg("test").await.unwrap();
+    drop(server_ctrl);
 
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
@@ -299,8 +304,6 @@ async fn test_client_pairing_unexpected_response() {
     let (mut client_ctrl, mut server_ctrl) = control_pair().await;
 
     let server_task = tokio::spawn(async move {
-        // Wait for ClientHello
-        let _hello = server_ctrl.recv_msg("test").await.unwrap();
         // Wait for PairingRequest but send wrong response
         let _request = server_ctrl.recv_msg("test").await.unwrap();
         server_ctrl
@@ -377,8 +380,7 @@ async fn test_client_pairing_stream_closed_unexpectedly() {
     let (mut client_ctrl, mut server_ctrl) = control_pair().await;
 
     let server_task = tokio::spawn(async move {
-        // Wait for ClientHello and PairingRequest, then close stream
-        let _hello = server_ctrl.recv_msg("test").await.unwrap();
+        // Wait for PairingRequest, then close stream
         let _request = server_ctrl.recv_msg("test").await.unwrap();
         server_ctrl.sender.stream.finish().unwrap();
     });
@@ -419,7 +421,7 @@ async fn test_auth_invalid_signature_rejected() {
     let mut trust_db = TrustDatabase::new();
 
     let (client_key, _) = tokio::join!(
-        client_pairing(&mut client_ctrl, pin),
+        full_client_pairing(&mut client_ctrl, pin),
         host_dispatch(&mut server_ctrl, pin, &mut trust_db, "test-device"),
     );
     let key = client_key.unwrap();
@@ -592,8 +594,6 @@ async fn test_client_pairing_result_unexpected_message() {
     let pin = "123456";
 
     let server_task = tokio::spawn(async move {
-        // Consume ClientHello
-        let _hello = server_ctrl.recv_msg("test").await.unwrap();
         // Consume PairingRequest
         let _request = server_ctrl.recv_msg("test").await.unwrap();
         // Send PairingResponse (dummy SPAKE2 message)
@@ -704,8 +704,6 @@ async fn test_client_pairing_spake2_finish_fails_with_garbage_message() {
     let pin = "123456";
 
     let server_task = tokio::spawn(async move {
-        // Wait for ClientHello
-        let _hello = server_ctrl.recv_msg("test").await.unwrap();
         // Wait for PairingRequest
         let _request = server_ctrl.recv_msg("test").await.unwrap();
         // Send garbage as PairingResponse instead of valid SPAKE2 message


### PR DESCRIPTION
## Summary

- **Bug:** Client blocked on stdin waiting for PIN before sending `ClientHello(Pair)`, so the host never received the intent and never displayed the PIN — a deadlock during `--pair` flow.
- **Fix:** Extract `client_send_pair_intent()` from `client_pairing()` so the CLI sends the pairing intent first, the host generates and displays the PIN, then the client prompts the user.
- Updated all pairing tests to use the new two-step API.

## Test plan

- [x] All 250 tests pass
- [x] All 29 pairing tests pass
- [x] `cargo make lint-test-coverage` exits 0
- [ ] Manual test: run server, run client with `--pair`, verify PIN appears on server before client prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)