### PR TITLE
feat(video): replace scrap with ScreenCaptureKit on macOS

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,16 @@
+# On macOS, the `screencapturekit` crate's Swift bridge requires the Swift
+# concurrency runtime.  Add rpath entries so all binaries (including test
+# runners) can find libswift_Concurrency.dylib.
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-Wl,-rpath,/usr/lib/swift",
+    "-C", "link-arg=-Wl,-rpath,/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx",
+    "-C", "link-arg=-Wl,-rpath,/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
+]
+
+[target.x86_64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-Wl,-rpath,/usr/lib/swift",
+    "-C", "link-arg=-Wl,-rpath,/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx",
+    "-C", "link-arg=-Wl,-rpath,/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2295,6 +2295,7 @@ dependencies = [
  "pollster",
  "rayplay-core",
  "scrap",
+ "screencapturekit",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2571,6 +2572,12 @@ dependencies = [
  "libc",
  "winapi 0.2.8",
 ]
+
+[[package]]
+name = "screencapturekit"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b732b2db50b25cfbcb171e1b7abda06e77873aeef493e635eb209482fdd149"
 
 [[package]]
 name = "sctk-adwaita"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -69,12 +69,12 @@ args = ["fmt", "--all"]
 clear = true
 description = "Coverage check — fails if line coverage drops below 96%"
 command = "cargo"
-args = ["llvm-cov", "--workspace", "--fail-under-lines", "96", "--ignore-filename-regex", "main\\.rs|render_window\\.rs|wgpu_surface\\.rs|wgpu_iosurface\\.rs|ffmpeg_enc\\.rs|ffmpeg_dec\\.rs|test_helper\\.rs|scrap_capture\\.rs|capture_factory\\.rs|transport_tls\\.rs|trust_store\\.rs|client_key_store\\.rs|platform_dirs\\.rs|host_pairing_glue\\.rs|connect\\.rs|receive\\.rs"]
+args = ["llvm-cov", "--workspace", "--fail-under-lines", "96", "--ignore-filename-regex", "main\\.rs|render_window\\.rs|wgpu_surface\\.rs|wgpu_iosurface\\.rs|ffmpeg_enc\\.rs|ffmpeg_dec\\.rs|test_helper\\.rs|scrap_capture\\.rs|capture_factory\\.rs|transport_tls\\.rs|trust_store\\.rs|client_key_store\\.rs|platform_dirs\\.rs|host_pairing_glue\\.rs|connect\\.rs|receive\\.rs|screen_permission_macos\\.rs|sck_capture\\.rs|host_capture_macos\\.rs"]
 
 [tasks.coverage-html]
 description = "Generate LLVM coverage report (HTML, opens browser)"
 script = [
-    '''cargo llvm-cov --workspace --html --ignore-filename-regex "main\\.rs|render_window\\.rs|wgpu_surface\\.rs|wgpu_iosurface\\.rs|ffmpeg_enc\\.rs|ffmpeg_dec\\.rs|test_helper\\.rs|scrap_capture\\.rs|capture_factory\\.rs|transport_tls\\.rs|trust_store\\.rs|client_key_store\\.rs|platform_dirs\\.rs|host_pairing_glue\\.rs|connect\\.rs|receive\\.rs"''',
+    '''cargo llvm-cov --workspace --html --ignore-filename-regex "main\\.rs|render_window\\.rs|wgpu_surface\\.rs|wgpu_iosurface\\.rs|ffmpeg_enc\\.rs|ffmpeg_dec\\.rs|test_helper\\.rs|scrap_capture\\.rs|capture_factory\\.rs|transport_tls\\.rs|trust_store\\.rs|client_key_store\\.rs|platform_dirs\\.rs|host_pairing_glue\\.rs|connect\\.rs|receive\\.rs|screen_permission_macos\\.rs|sck_capture\\.rs|host_capture_macos\\.rs"''',
     "open target/llvm-cov/html/index.html"
 ]
 

--- a/crates/rayplay-cli/src/host.rs
+++ b/crates/rayplay-cli/src/host.rs
@@ -415,9 +415,23 @@ pub(crate) async fn stream(
     stream_with_zero_copy_pipeline(transport, capturer, encoder, token).await
 }
 
-/// Non-Windows streaming path — uses the software fallback pipeline
+/// Non-Windows streaming path — delegates to platform-specific modules.
+///
+/// On macOS, uses [`host_capture_macos`](crate::host_capture_macos) which
+/// checks Screen Recording permission and captures via ScreenCaptureKit.
+/// On other non-Windows platforms, uses the software fallback pipeline.
+#[cfg(target_os = "macos")]
+pub(crate) async fn stream(
+    transport: QuicVideoTransport,
+    config: HostConfig,
+    token: CancellationToken,
+) -> Result<()> {
+    crate::host_capture_macos::stream(transport, config, token).await
+}
+
+/// Non-Windows/non-macOS streaming path — uses the software fallback pipeline
 /// (scrap capturer + openh264/ffmpeg encoder) via the factory functions.
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 pub(crate) async fn stream(
     transport: QuicVideoTransport,
     config: HostConfig,

--- a/crates/rayplay-cli/src/host/tests.rs
+++ b/crates/rayplay-cli/src/host/tests.rs
@@ -900,9 +900,9 @@ async fn test_layer4_stream_with_pipeline_encode_thread_panic_propagates_as_erro
     assert!(result.unwrap_err().to_string().contains("panicked"));
 }
 
-// ── stream (non-Windows stub) ────────────────────────────────────────────
+// ── stream (non-Windows/non-macOS stub) ──────────────────────────────────
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 #[tokio::test]
 async fn test_stream_returns_unsupported_error_on_non_windows() {
     let bind: SocketAddr = "127.0.0.1:0".parse().unwrap();
@@ -923,7 +923,7 @@ async fn test_stream_returns_unsupported_error_on_non_windows() {
     );
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 #[tokio::test]
 async fn test_serve_continues_after_non_windows_stream_error() {
     let bind: SocketAddr = "127.0.0.1:0".parse().unwrap();

--- a/crates/rayplay-cli/src/host_capture_macos.rs
+++ b/crates/rayplay-cli/src/host_capture_macos.rs
@@ -1,0 +1,67 @@
+//! macOS-specific capture initialization for the host.
+//!
+//! Checks Screen Recording permission and initializes the capture pipeline
+//! via ScreenCaptureKit.  Excluded from coverage — platform I/O that
+//! requires a real display.
+
+use anyhow::Result;
+use rayplay_network::QuicVideoTransport;
+use rayplay_video::encoder::EncoderConfig;
+use tokio_util::sync::CancellationToken;
+
+use crate::host::{HostConfig, stream_with_pipeline};
+
+/// Checks Screen Recording permission, then creates the capture and encode
+/// pipeline and streams to the connected client.
+pub(crate) async fn stream(
+    transport: QuicVideoTransport,
+    config: HostConfig,
+    token: CancellationToken,
+) -> Result<()> {
+    use rayplay_video::{CaptureConfig, create_capturer, encoder::create_encoder};
+
+    wait_for_screen_recording_permission().await?;
+
+    let cap_config = CaptureConfig {
+        target_fps: config.encoder_config.fps,
+        acquire_timeout_ms: 100,
+    };
+    let capturer =
+        create_capturer(cap_config, config.pipeline_mode).map_err(anyhow::Error::from)?;
+    let (cap_width, cap_height) = capturer.resolution();
+
+    let enc_config = EncoderConfig::new(cap_width, cap_height, config.encoder_config.fps)
+        .with_bitrate(config.encoder_config.bitrate);
+    let encoder = create_encoder(enc_config, config.pipeline_mode).map_err(anyhow::Error::from)?;
+
+    stream_with_pipeline(transport, capturer, encoder, token).await
+}
+
+/// Polls for macOS Screen Recording permission, prompting the user to grant it.
+///
+/// On the first check, opens System Settings to the Screen Recording pane.
+/// Then polls every 2 seconds until the permission is granted.
+async fn wait_for_screen_recording_permission() -> Result<()> {
+    use rayplay_video::screen_permission_macos::{
+        has_screen_recording_permission, request_screen_recording_permission,
+    };
+
+    if has_screen_recording_permission() {
+        return Ok(());
+    }
+
+    tracing::warn!("Screen Recording permission is not granted.");
+    tracing::warn!("Please enable it in System Settings > Privacy & Security > Screen Recording.");
+
+    // Trigger the system prompt / open Settings pane.
+    let _ = request_screen_recording_permission();
+
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        if has_screen_recording_permission() {
+            tracing::info!("Screen Recording permission granted.");
+            return Ok(());
+        }
+        tracing::info!("Waiting for Screen Recording permission...");
+    }
+}

--- a/crates/rayplay-cli/src/main.rs
+++ b/crates/rayplay-cli/src/main.rs
@@ -1,6 +1,8 @@
 //! `rayhost` binary — entry point for the `RayPlay` host streaming server (UC-006, UC-008, UC-016).
 
 mod host;
+#[cfg(target_os = "macos")]
+mod host_capture_macos;
 mod host_pairing_glue;
 
 use std::sync::Arc;

--- a/crates/rayplay-network/src/pairing.rs
+++ b/crates/rayplay-network/src/pairing.rs
@@ -139,9 +139,7 @@ pub async fn host_pairing(
 /// # Errors
 ///
 /// Returns a [`SessionError`] if the message cannot be sent.
-pub async fn client_send_pair_intent(
-    control: &mut ControlChannel,
-) -> Result<(), SessionError> {
+pub async fn client_send_pair_intent(control: &mut ControlChannel) -> Result<(), SessionError> {
     control
         .send_msg(&ControlMessage::ClientHello(ClientIntent::Pair))
         .await

--- a/crates/rayplay-video/Cargo.toml
+++ b/crates/rayplay-video/Cargo.toml
@@ -32,6 +32,7 @@ windows = { version = "0.58", features = [
 [target.'cfg(target_os = "macos")'.dependencies]
 metal = { workspace = true }
 objc  = { workspace = true }
+screencapturekit = "1"
 
 [features]
 default = ["fallback"]

--- a/crates/rayplay-video/src/capture_factory.rs
+++ b/crates/rayplay-video/src/capture_factory.rs
@@ -38,7 +38,12 @@ pub fn create_capturer(
         let device = Arc::new(SharedD3D11Device::new()?);
         DxgiCapture::new(config, device).map(|c| Box::new(c) as Box<dyn ScreenCapturer>)
     }
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
+    {
+        use crate::sck_capture::SckCapturer;
+        SckCapturer::new(config).map(|c| Box::new(c) as Box<dyn ScreenCapturer>)
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     {
         #[cfg(feature = "fallback")]
         {
@@ -57,14 +62,16 @@ pub fn create_capturer(
 mod tests {
     use super::*;
 
-    #[cfg(all(not(target_os = "windows"), not(feature = "fallback")))]
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    #[cfg(not(feature = "fallback"))]
     #[test]
     fn test_create_capturer_unsupported_on_non_windows() {
         let result = create_capturer(CaptureConfig::default(), PipelineMode::Auto);
         assert!(matches!(result, Err(CaptureError::UnsupportedPlatform)));
     }
 
-    #[cfg(all(not(target_os = "windows"), feature = "fallback"))]
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    #[cfg(feature = "fallback")]
     #[test]
     fn test_create_capturer_returns_scrap_on_non_windows_with_fallback() {
         let result = create_capturer(CaptureConfig::default(), PipelineMode::Auto);

--- a/crates/rayplay-video/src/lib.rs
+++ b/crates/rayplay-video/src/lib.rs
@@ -30,6 +30,10 @@ pub mod packet;
 pub mod pipeline_mode;
 pub mod render_window;
 pub mod renderer;
+#[cfg(target_os = "macos")]
+pub(crate) mod sck_capture;
+#[cfg(target_os = "macos")]
+pub mod screen_permission_macos;
 pub mod videotoolbox;
 #[cfg(target_os = "macos")]
 mod wgpu_iosurface;

--- a/crates/rayplay-video/src/sck_capture.rs
+++ b/crates/rayplay-video/src/sck_capture.rs
@@ -1,0 +1,120 @@
+//! macOS screen capture via Apple's `ScreenCaptureKit` framework.
+//!
+//! Replaces the `scrap`-based capturer on macOS 12.3+.  Uses
+//! `SCStream` with a callback that pushes frames into a bounded
+//! channel, bridging the callback-based API to the synchronous
+//! [`ScreenCapturer`] trait.
+//!
+//! Excluded from coverage: platform-specific capture code that
+//! requires a real display.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crossbeam_channel::{Receiver, Sender, TrySendError};
+use screencapturekit::cv::CVPixelBufferLockFlags;
+use screencapturekit::prelude::*;
+
+use crate::capture::{CaptureConfig, CaptureError, CapturedFrame, ScreenCapturer, build_frame};
+
+struct FrameHandler {
+    tx: Sender<Vec<u8>>,
+}
+
+impl SCStreamOutputTrait for FrameHandler {
+    fn did_output_sample_buffer(&self, sample: CMSampleBuffer, _of_type: SCStreamOutputType) {
+        let Some(pixel_buffer) = sample.image_buffer() else {
+            return;
+        };
+
+        let Ok(lock) = pixel_buffer.lock(CVPixelBufferLockFlags::READ_ONLY) else {
+            return;
+        };
+
+        let data = lock.as_slice().to_vec();
+
+        // Non-blocking send — drop the frame if the consumer is behind.
+        match self.tx.try_send(data) {
+            Ok(()) | Err(TrySendError::Full(_)) => {}
+            Err(TrySendError::Disconnected(_)) => {}
+        }
+    }
+}
+
+pub struct SckCapturer {
+    _stream: Arc<SCStream>,
+    rx: Receiver<Vec<u8>>,
+    width: u32,
+    height: u32,
+    timeout: Duration,
+}
+
+impl SckCapturer {
+    /// Creates a new `SckCapturer` targeting the primary display.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CaptureError::InitializationFailed`] if the display
+    /// cannot be enumerated or the capture stream cannot start.
+    pub fn new(config: CaptureConfig) -> Result<Self, CaptureError> {
+        let content = SCShareableContent::get()
+            .map_err(|e| CaptureError::InitializationFailed(format!("shareable content: {e}")))?;
+
+        let displays = content.displays();
+        let display = displays
+            .first()
+            .ok_or_else(|| CaptureError::InitializationFailed("no display found".to_string()))?;
+
+        #[allow(clippy::cast_sign_loss)]
+        let width = display.width() as u32;
+        #[allow(clippy::cast_sign_loss)]
+        let height = display.height() as u32;
+
+        let stream_config = SCStreamConfiguration::new()
+            .with_width(display.width())
+            .with_height(display.height())
+            .with_pixel_format(PixelFormat::BGRA)
+            .with_shows_cursor(true);
+
+        let filter = SCContentFilter::create()
+            .with_display(display)
+            .with_excluding_windows(&[])
+            .build();
+
+        let (tx, rx) = crossbeam_channel::bounded(1);
+
+        let handler = FrameHandler { tx };
+        let mut stream = SCStream::new(&filter, &stream_config);
+        stream.add_output_handler(handler, SCStreamOutputType::Screen);
+        stream
+            .start_capture()
+            .map_err(|e| CaptureError::InitializationFailed(format!("start capture: {e}")))?;
+
+        let timeout = Duration::from_millis(u64::from(config.acquire_timeout_ms));
+
+        Ok(Self {
+            _stream: Arc::new(stream),
+            rx,
+            width,
+            height,
+            timeout,
+        })
+    }
+}
+
+impl ScreenCapturer for SckCapturer {
+    fn capture_frame(&mut self) -> Result<CapturedFrame, CaptureError> {
+        let data = self.rx.recv_timeout(self.timeout).map_err(|e| match e {
+            crossbeam_channel::RecvTimeoutError::Timeout => CaptureError::Timeout(self.timeout),
+            crossbeam_channel::RecvTimeoutError::Disconnected => {
+                CaptureError::AcquireFailed("capture stream disconnected".to_string())
+            }
+        })?;
+
+        Ok(build_frame(data, self.width, self.height))
+    }
+
+    fn resolution(&self) -> (u32, u32) {
+        (self.width, self.height)
+    }
+}

--- a/crates/rayplay-video/src/screen_permission_macos.rs
+++ b/crates/rayplay-video/src/screen_permission_macos.rs
@@ -1,0 +1,31 @@
+//! macOS Screen Recording permission check via `CoreGraphics` FFI.
+//!
+//! Uses `CGPreflightScreenCaptureAccess` (macOS 10.15+) to check whether
+//! the current process has Screen Recording permission, and
+//! `CGRequestScreenCaptureAccess` to trigger the system prompt.
+//!
+//! Excluded from coverage: thin FFI wrapper over OS APIs.
+
+unsafe extern "C" {
+    fn CGPreflightScreenCaptureAccess() -> bool;
+    fn CGRequestScreenCaptureAccess() -> bool;
+}
+
+/// Returns `true` if Screen Recording permission is already granted.
+#[must_use]
+pub fn has_screen_recording_permission() -> bool {
+    // SAFETY: `CGPreflightScreenCaptureAccess` is a stable CoreGraphics API
+    // with no preconditions — safe to call from any thread.
+    unsafe { CGPreflightScreenCaptureAccess() }
+}
+
+/// Requests Screen Recording permission from the user.
+///
+/// On first call, this opens System Settings to the Screen Recording pane.
+/// Returns `true` if permission was already granted, `false` otherwise.
+/// The user must grant permission and restart the app for it to take effect.
+#[must_use]
+pub fn request_screen_recording_permission() -> bool {
+    // SAFETY: same as above — stable CoreGraphics API, no preconditions.
+    unsafe { CGRequestScreenCaptureAccess() }
+}


### PR DESCRIPTION
## Summary

- Replace `scrap` crate with Apple's `ScreenCaptureKit` (via `screencapturekit` crate) for macOS screen capture — `scrap` uses deprecated `CGDisplayStreamCreateWithDispatchQueue` which is broken on macOS 15+/Tahoe 26
- Add Screen Recording permission check loop that detects missing permission and prompts the user before attempting capture
- Add `.cargo/config.toml` with Swift runtime rpath so `libswift_Concurrency.dylib` is found at runtime
- Windows capture path (DxgiCapture + NvencEncoder) is completely untouched

## Test plan

- [ ] Verify `cargo make ci` passes (fmt, clippy, tests, coverage ≥96%)
- [ ] Manual test: run `rayhost` on macOS — should prompt for Screen Recording permission if not granted
- [ ] Manual test: after granting permission, capture stream should initialize successfully
- [ ] Verify Windows host build is unaffected (all macOS code behind `#[cfg(target_os = "macos")]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)