### PR TITLE
feat(network): codec negotiation via stream handshake

### DIFF
--- a/crates/rayplay-cli/src/client/config/tests.rs
+++ b/crates/rayplay-cli/src/client/config/tests.rs
@@ -185,9 +185,7 @@ impl TestCertGuard {
 impl Drop for TestCertGuard {
     fn drop(&mut self) {
         // Best-effort cleanup: remove the test cert file
-        let _ =
-            rayplay_network::server_cert_store::load_server_cert(&self.host, self.port)
-                .ok();
+        let _ = rayplay_network::server_cert_store::load_server_cert(&self.host, self.port).ok();
         // We can't easily get the path from the public API, so just leave it.
         // The unique host name ensures it won't interfere with anything.
     }

--- a/crates/rayplay-cli/src/client/connect.rs
+++ b/crates/rayplay-cli/src/client/connect.rs
@@ -1,9 +1,11 @@
 //! QUIC connection setup for the `rayview` client (UC-007, UC-008).
 
-use std::{future::Future, net::SocketAddr};
+use std::{future::Future, net::SocketAddr, str::FromStr};
 
 use anyhow::Result;
-use rayplay_network::QuicVideoTransport;
+use rayplay_core::session::StreamParams;
+use rayplay_network::{QuicVideoTransport, client_handshake};
+use rayplay_video::encoder::Codec;
 use tokio_util::sync::CancellationToken;
 
 /// Connects to a `RayPlay` host and calls `on_connect` with the established transport.
@@ -117,6 +119,47 @@ where
     }
 }
 
+/// Performs codec negotiation handshake and starts decoding with the negotiated codec.
+async fn run_pipeline_with_handshake(
+    transport: QuicVideoTransport,
+    mut control: rayplay_network::ControlChannel,
+    pipeline_mode: rayplay_video::PipelineMode,
+    frame_tx: crossbeam_channel::Sender<rayplay_video::DecodedFrame>,
+    token: CancellationToken,
+) -> Result<()> {
+    use rayplay_video::create_decoder;
+
+    // Send handshake with desired params (can be placeholder since host returns actual params)
+    let desired_params = StreamParams {
+        width: 1920,
+        height: 1080,
+        fps: 60,
+        codec: "hevc".to_string(), // preferred codec
+    };
+
+    let actual_params = client_handshake(&mut control, desired_params)
+        .await
+        .map_err(|e| anyhow::anyhow!("codec negotiation failed: {e}"))?;
+
+    // Parse the actual codec returned by the host
+    let actual_codec = Codec::from_str(&actual_params.codec)
+        .map_err(|e| anyhow::anyhow!("unsupported codec '{}': {e}", actual_params.codec))?;
+
+    tracing::info!(
+        codec = %actual_codec,
+        width = actual_params.width,
+        height = actual_params.height,
+        fps = actual_params.fps,
+        "Codec negotiation complete"
+    );
+
+    // Create decoder with the actual negotiated codec
+    let decoder = create_decoder(actual_codec, pipeline_mode)
+        .map_err(|e| anyhow::anyhow!("decoder initialisation failed: {e}"))?;
+
+    super::receive::run_receive_loop(transport, decoder, frame_tx, token).await
+}
+
 /// Connects to the host in `config` and runs the full receive-decode pipeline
 /// with automatic reconnection on failure.
 ///
@@ -133,8 +176,6 @@ pub async fn connect(
     frame_tx: crossbeam_channel::Sender<rayplay_video::DecodedFrame>,
     token: CancellationToken,
 ) -> Result<()> {
-    use rayplay_video::{Codec, create_decoder};
-
     let server_addr = config.server_addr;
     let pipeline_mode = config.pipeline_mode;
     let reconnect_timeout = config.reconnect_timeout;
@@ -186,10 +227,8 @@ pub async fn connect(
             tracing::warn!("Could not extract server certificate from connection.");
         }
 
-        // After pairing, run the decode pipeline on this connection
-        let decoder = create_decoder(Codec::Hevc, pipeline_mode)
-            .map_err(|e| anyhow::anyhow!("decoder initialisation failed: {e}"))?;
-        super::receive::run_receive_loop(transport, decoder, frame_tx, token).await
+        // After pairing, run the decode pipeline with codec negotiation
+        run_pipeline_with_handshake(transport, control, pipeline_mode, frame_tx, token).await
     } else {
         // Normal mode: cert-based connect with challenge-response auth
         let cert_bytes = config.load_cert_bytes()?;
@@ -207,12 +246,13 @@ pub async fn connect(
                 let frame_tx = frame_tx.clone();
                 let signing_key = signing_key.clone();
                 async move {
+                    let mut control = transport
+                        .open_control()
+                        .await
+                        .map_err(|e| anyhow::anyhow!("failed to open control channel: {e}"))?;
+
                     // Authenticate with saved signing key if available
                     if let Some(ref key) = signing_key {
-                        let mut control = transport
-                            .open_control()
-                            .await
-                            .map_err(|e| anyhow::anyhow!("failed to open control channel: {e}"))?;
                         rayplay_network::client_auth_response(&mut control, key)
                             .await
                             .map_err(|e| anyhow::anyhow!("authentication failed: {e}"))?;
@@ -223,9 +263,9 @@ pub async fn connect(
                         );
                     }
 
-                    let decoder = create_decoder(Codec::Hevc, pipeline_mode)
-                        .map_err(|e| anyhow::anyhow!("decoder initialisation failed: {e}"))?;
-                    super::receive::run_receive_loop(transport, decoder, frame_tx, child).await
+                    // Run the decode pipeline with codec negotiation
+                    run_pipeline_with_handshake(transport, control, pipeline_mode, frame_tx, child)
+                        .await
                 }
             },
         )

--- a/crates/rayplay-cli/src/host.rs
+++ b/crates/rayplay-cli/src/host.rs
@@ -385,59 +385,18 @@ pub(crate) async fn stream_with_zero_copy_pipeline(
     result
 }
 
-/// Resolves platform-specific capture and encoder then calls
-/// [`stream_with_zero_copy_pipeline`] for the zero-copy GPU path.
-#[cfg(target_os = "windows")]
-pub(crate) async fn stream(
-    transport: QuicVideoTransport,
-    config: HostConfig,
-    token: CancellationToken,
-) -> Result<()> {
-    use std::sync::Arc;
-
-    use rayplay_video::{
-        CaptureConfig, SharedD3D11Device, capture::ZeroCopyCapturer, dxgi_capture::DxgiCapture,
-        nvenc::NvencEncoder,
-    };
-
-    let device = Arc::new(SharedD3D11Device::new().map_err(anyhow::Error::from)?);
-
-    let cap_config = CaptureConfig {
-        target_fps: config.encoder_config.fps,
-        acquire_timeout_ms: 100,
-    };
-    let capturer = DxgiCapture::new(cap_config, device.clone()).map_err(anyhow::Error::from)?;
-    let (cap_width, cap_height) = <DxgiCapture as ZeroCopyCapturer>::resolution(&capturer);
-
-    let enc_config = EncoderConfig::new(cap_width, cap_height, config.encoder_config.fps)
-        .with_bitrate(config.encoder_config.bitrate);
-    let encoder = NvencEncoder::new(enc_config).map_err(anyhow::Error::from)?;
-
-    stream_with_zero_copy_pipeline(transport, capturer, encoder, token).await
-}
-
-/// Non-Windows streaming path — delegates to platform-specific modules.
+/// Creates the capture and encoder pipeline but does not start streaming.
 ///
-/// On macOS, uses [`host_capture_macos`](crate::host_capture_macos) which
-/// checks Screen Recording permission and captures via `ScreenCaptureKit`.
-/// On other non-Windows platforms, uses the software fallback pipeline.
-#[cfg(target_os = "macos")]
-pub(crate) async fn stream(
-    transport: QuicVideoTransport,
-    config: HostConfig,
-    token: CancellationToken,
-) -> Result<()> {
-    crate::host_capture_macos::stream(transport, config, token).await
-}
-
-/// Non-Windows/non-macOS streaming path — uses the software fallback pipeline
-/// (scrap capturer + openh264/ffmpeg encoder) via the factory functions.
+/// Initializes the capturer and encoder with the actual capture resolution
+/// for the software fallback pipeline.
+///
+/// # Errors
+///
+/// Returns an error if capture initialization fails or encoder creation fails.
 #[cfg(not(any(target_os = "windows", target_os = "macos")))]
-pub(crate) async fn stream(
-    transport: QuicVideoTransport,
-    config: HostConfig,
-    token: CancellationToken,
-) -> Result<()> {
+pub(crate) async fn prepare_pipeline(
+    config: &HostConfig,
+) -> Result<(Box<dyn ScreenCapturer>, Box<dyn VideoEncoder>)> {
     use rayplay_video::{CaptureConfig, create_capturer, encoder::create_encoder};
 
     let cap_config = CaptureConfig {
@@ -449,10 +408,10 @@ pub(crate) async fn stream(
     let (cap_width, cap_height) = capturer.resolution();
 
     let enc_config = EncoderConfig::new(cap_width, cap_height, config.encoder_config.fps)
-        .with_bitrate(config.encoder_config.bitrate);
+        .with_bitrate(config.encoder_config.bitrate.clone());
     let encoder = create_encoder(enc_config, config.pipeline_mode).map_err(anyhow::Error::from)?;
 
-    stream_with_pipeline(transport, capturer, encoder, token).await
+    Ok((capturer, encoder))
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/rayplay-cli/src/host_capture_macos.rs
+++ b/crates/rayplay-cli/src/host_capture_macos.rs
@@ -5,19 +5,25 @@
 //! requires a real display.
 
 use anyhow::Result;
-use rayplay_network::QuicVideoTransport;
-use rayplay_video::encoder::EncoderConfig;
-use tokio_util::sync::CancellationToken;
+use rayplay_video::{
+    capture::ScreenCapturer,
+    encoder::{EncoderConfig, VideoEncoder},
+};
 
-use crate::host::{HostConfig, stream_with_pipeline};
+use crate::host::HostConfig;
 
-/// Checks Screen Recording permission, then creates the capture and encode
-/// pipeline and streams to the connected client.
-pub(crate) async fn stream(
-    transport: QuicVideoTransport,
-    config: HostConfig,
-    token: CancellationToken,
-) -> Result<()> {
+/// Creates the capture and encoder pipeline but does not start streaming.
+///
+/// Checks Screen Recording permission first, then initializes the capturer
+/// and encoder with the actual capture resolution.
+///
+/// # Errors
+///
+/// Returns an error if Screen Recording permission is denied, capture
+/// initialization fails, or encoder creation fails.
+pub(crate) async fn prepare_pipeline(
+    config: &HostConfig,
+) -> Result<(Box<dyn ScreenCapturer>, Box<dyn VideoEncoder>)> {
     use rayplay_video::{CaptureConfig, create_capturer, encoder::create_encoder};
 
     wait_for_screen_recording_permission().await?;
@@ -31,10 +37,10 @@ pub(crate) async fn stream(
     let (cap_width, cap_height) = capturer.resolution();
 
     let enc_config = EncoderConfig::new(cap_width, cap_height, config.encoder_config.fps)
-        .with_bitrate(config.encoder_config.bitrate);
+        .with_bitrate(config.encoder_config.bitrate.clone());
     let encoder = create_encoder(enc_config, config.pipeline_mode).map_err(anyhow::Error::from)?;
 
-    stream_with_pipeline(transport, capturer, encoder, token).await
+    Ok((capturer, encoder))
 }
 
 /// Polls for macOS Screen Recording permission, prompting the user to grant it.

--- a/crates/rayplay-cli/src/host_pairing_glue.rs
+++ b/crates/rayplay-cli/src/host_pairing_glue.rs
@@ -6,11 +6,11 @@
 
 use anyhow::Result;
 use rayplay_core::pairing::TrustDatabase;
-use rayplay_core::session::{ClientIntent, ControlMessage};
-use rayplay_network::{QuicVideoTransport, host_auth_challenge, host_pairing};
+use rayplay_core::session::{ClientIntent, ControlMessage, StreamParams};
+use rayplay_network::{QuicVideoTransport, host_auth_challenge, host_handshake, host_pairing};
 use tokio_util::sync::CancellationToken;
 
-use crate::host::{HostConfig, stream};
+use crate::host::{HostConfig, stream_with_pipeline};
 
 /// Authenticates the client via challenge-response or PIN pairing, then streams.
 pub(crate) async fn authenticate_and_stream(
@@ -44,7 +44,7 @@ pub(crate) async fn authenticate_and_stream(
                     tracing::info!(client_id = %client.client_id, "Trusted client authenticated");
                     drop(db);
                     save_trust_db_if_possible(&trust_db).await;
-                    stream(transport, config, token).await
+                    stream_with_handshake(transport, config, control, token).await
                 }
                 Err(e) => {
                     tracing::warn!(error = %e, "Authentication failed");
@@ -70,8 +70,109 @@ pub(crate) async fn authenticate_and_stream(
             tracing::info!(client_id = %client.client_id, "Client paired successfully");
             save_trust_db_if_possible(&trust_db).await;
 
-            stream(transport, config, token).await
+            stream_with_handshake(transport, config, control, token).await
         }
+    }
+}
+
+/// Performs codec negotiation handshake then streams with the negotiated codec.
+async fn stream_with_handshake(
+    transport: QuicVideoTransport,
+    config: HostConfig,
+    mut control: rayplay_network::ControlChannel,
+    token: CancellationToken,
+) -> Result<()> {
+    // On Windows, we use the zero-copy pipeline which doesn't have a prepare_pipeline function
+    #[cfg(target_os = "windows")]
+    {
+        use rayplay_video::{
+            CaptureConfig, SharedD3D11Device, capture::ZeroCopyCapturer, dxgi_capture::DxgiCapture,
+            encoder::EncoderConfig, nvenc::NvencEncoder,
+        };
+        use std::sync::Arc;
+
+        let device = Arc::new(SharedD3D11Device::new().map_err(anyhow::Error::from)?);
+
+        let cap_config = CaptureConfig {
+            target_fps: config.encoder_config.fps,
+            acquire_timeout_ms: 100,
+        };
+        let capturer = DxgiCapture::new(cap_config, device.clone()).map_err(anyhow::Error::from)?;
+        let (cap_width, cap_height) = <DxgiCapture as ZeroCopyCapturer>::resolution(&capturer);
+
+        let enc_config = EncoderConfig::new(cap_width, cap_height, config.encoder_config.fps)
+            .with_bitrate(config.encoder_config.bitrate);
+        let encoder = NvencEncoder::new(enc_config).map_err(anyhow::Error::from)?;
+
+        // Get actual codec from encoder
+        let actual_codec = encoder.config().codec;
+
+        // Build stream params with actual values
+        let stream_params = StreamParams {
+            width: cap_width,
+            height: cap_height,
+            fps: config.encoder_config.fps,
+            codec: actual_codec.to_string(),
+        };
+
+        // Run handshake - we return the actual params regardless of what client proposes
+        let _agreed_params = host_handshake(&mut control, |_proposed| stream_params.clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("handshake failed: {e}"))?;
+
+        tracing::info!(
+            codec = %actual_codec,
+            width = cap_width,
+            height = cap_height,
+            fps = config.encoder_config.fps,
+            "Codec negotiation complete"
+        );
+
+        // Use the zero-copy streaming path for Windows
+        crate::host::stream_with_zero_copy_pipeline(transport, capturer, encoder, token).await
+    }
+
+    // On macOS and other platforms, use prepare_pipeline
+    #[cfg(not(target_os = "windows"))]
+    {
+        // Prepare the pipeline to get actual encoder config
+        let (capturer, encoder) = {
+            #[cfg(target_os = "macos")]
+            {
+                crate::host_capture_macos::prepare_pipeline(&config).await?
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                crate::host::prepare_pipeline(&config).await?
+            }
+        };
+
+        // Get actual codec from encoder
+        let actual_codec = encoder.config().codec;
+
+        // Build stream params with actual values
+        let stream_params = StreamParams {
+            width: encoder.config().width,
+            height: encoder.config().height,
+            fps: encoder.config().fps,
+            codec: actual_codec.to_string(),
+        };
+
+        // Run handshake - we return the actual params regardless of what client proposes
+        let _agreed_params = host_handshake(&mut control, |_proposed| stream_params.clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("handshake failed: {e}"))?;
+
+        tracing::info!(
+            codec = %actual_codec,
+            width = encoder.config().width,
+            height = encoder.config().height,
+            fps = encoder.config().fps,
+            "Codec negotiation complete"
+        );
+
+        // Use the regular streaming path for non-Windows platforms
+        stream_with_pipeline(transport, capturer, encoder, token).await
     }
 }
 

--- a/crates/rayplay-network/src/lib.rs
+++ b/crates/rayplay-network/src/lib.rs
@@ -11,7 +11,6 @@
 //! ```
 
 pub mod client_key_store;
-pub mod server_cert_store;
 pub mod control;
 pub mod fragmenter;
 pub mod handshake;
@@ -19,6 +18,7 @@ pub mod keepalive;
 pub mod pairing;
 pub(crate) mod platform_dirs;
 pub mod reassembler;
+pub mod server_cert_store;
 pub mod transport;
 pub(crate) mod transport_tls;
 pub mod trust_store;

--- a/crates/rayplay-network/src/transport.rs
+++ b/crates/rayplay-network/src/transport.rs
@@ -171,9 +171,7 @@ impl QuicVideoTransport {
     #[must_use]
     pub fn peer_certificate(&self) -> Option<Vec<u8>> {
         let identity = self.connection.peer_identity()?;
-        let certs = identity
-            .downcast::<Vec<CertificateDer<'static>>>()
-            .ok()?;
+        let certs = identity.downcast::<Vec<CertificateDer<'static>>>().ok()?;
         certs.first().map(|c| c.as_ref().to_vec())
     }
 

--- a/crates/rayplay-network/src/transport/tests.rs
+++ b/crates/rayplay-network/src/transport/tests.rs
@@ -285,9 +285,8 @@ async fn test_peer_certificate_server_side_returns_none() {
     let bind: SocketAddr = "127.0.0.1:0".parse().unwrap();
     let (listener, cert_der) = QuicVideoTransport::listen(bind).unwrap();
     let server_addr = listener.local_addr().unwrap();
-    let _client_task = tokio::spawn(async move {
-        QuicVideoTransport::connect(server_addr, cert_der).await
-    });
+    let _client_task =
+        tokio::spawn(async move { QuicVideoTransport::connect(server_addr, cert_der).await });
 
     let server = listener.accept().await.expect("accept");
     // Server side: client does not present a certificate

--- a/crates/rayplay-video/src/encoder.rs
+++ b/crates/rayplay-video/src/encoder.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, str::FromStr};
 
 use thiserror::Error;
 
@@ -66,6 +66,29 @@ pub enum Codec {
     Hevc,
     /// H.264 / AVC — widely supported codec, hardware-accelerated on most GPUs.
     H264,
+}
+
+impl fmt::Display for Codec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Hevc => write!(f, "hevc"),
+            Self::H264 => write!(f, "h264"),
+        }
+    }
+}
+
+impl FromStr for Codec {
+    type Err = VideoError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "hevc" => Ok(Self::Hevc),
+            "h264" => Ok(Self::H264),
+            _ => Err(VideoError::UnsupportedCodec {
+                codec: s.to_string(),
+            }),
+        }
+    }
 }
 
 /// Encoder bitrate setting.
@@ -167,8 +190,8 @@ pub enum VideoError {
     #[error("encoder session not initialized")]
     NotInitialized,
 
-    #[error("unsupported codec: {codec:?}")]
-    UnsupportedCodec { codec: Codec },
+    #[error("unsupported codec: {codec}")]
+    UnsupportedCodec { codec: String },
 
     #[error("invalid frame dimensions: {width}x{height}")]
     InvalidDimensions { width: u32, height: u32 },

--- a/crates/rayplay-video/src/encoder/tests.rs
+++ b/crates/rayplay-video/src/encoder/tests.rs
@@ -154,14 +154,20 @@ fn test_video_error_not_initialized_message() {
 
 #[test]
 fn test_video_error_unsupported_codec_hevc_message() {
-    let msg = VideoError::UnsupportedCodec { codec: Codec::Hevc }.to_string();
-    assert!(msg.contains("Hevc"));
+    let msg = VideoError::UnsupportedCodec {
+        codec: "hevc".to_string(),
+    }
+    .to_string();
+    assert!(msg.contains("hevc"));
 }
 
 #[test]
 fn test_video_error_unsupported_codec_h264_message() {
-    let msg = VideoError::UnsupportedCodec { codec: Codec::H264 }.to_string();
-    assert!(msg.contains("H264"));
+    let msg = VideoError::UnsupportedCodec {
+        codec: "h264".to_string(),
+    }
+    .to_string();
+    assert!(msg.contains("h264"));
 }
 
 #[test]
@@ -309,6 +315,59 @@ fn test_codec_h264_clone() {
     let codec = Codec::H264;
     let cloned = codec.clone();
     assert_eq!(codec, cloned);
+}
+
+#[test]
+fn test_codec_display_hevc() {
+    assert_eq!(Codec::Hevc.to_string(), "hevc");
+}
+
+#[test]
+fn test_codec_display_h264() {
+    assert_eq!(Codec::H264.to_string(), "h264");
+}
+
+#[test]
+fn test_codec_from_str_hevc() {
+    let codec: Codec = "hevc".parse().unwrap();
+    assert_eq!(codec, Codec::Hevc);
+}
+
+#[test]
+fn test_codec_from_str_h264() {
+    let codec: Codec = "h264".parse().unwrap();
+    assert_eq!(codec, Codec::H264);
+}
+
+#[test]
+fn test_codec_from_str_invalid() {
+    let result: Result<Codec, _> = "vp9".parse();
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert!(matches!(error, VideoError::UnsupportedCodec { .. }));
+    assert!(error.to_string().contains("vp9"));
+}
+
+#[test]
+fn test_codec_from_str_empty() {
+    let result: Result<Codec, _> = "".parse();
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_codec_display_from_str_round_trip_hevc() {
+    let original = Codec::Hevc;
+    let string = original.to_string();
+    let parsed: Codec = string.parse().unwrap();
+    assert_eq!(original, parsed);
+}
+
+#[test]
+fn test_codec_display_from_str_round_trip_h264() {
+    let original = Codec::H264;
+    let string = original.to_string();
+    let parsed: Codec = string.parse().unwrap();
+    assert_eq!(original, parsed);
 }
 
 // ── EncoderInput ──────────────────────────────────────────────────────────

--- a/crates/rayplay-video/src/openh264_dec.rs
+++ b/crates/rayplay-video/src/openh264_dec.rs
@@ -35,7 +35,9 @@ impl OpenH264Decoder {
     /// or [`VideoError::DecodingFailed`] if the decoder cannot be initialized.
     pub fn new(codec: Codec) -> Result<Self, VideoError> {
         if codec != Codec::H264 {
-            return Err(VideoError::UnsupportedCodec { codec });
+            return Err(VideoError::UnsupportedCodec {
+                codec: codec.to_string(),
+            });
         }
 
         let api = openh264::OpenH264API::from_source();

--- a/crates/rayplay-video/src/openh264_enc.rs
+++ b/crates/rayplay-video/src/openh264_enc.rs
@@ -34,7 +34,7 @@ impl OpenH264Encoder {
     pub fn new(config: EncoderConfig) -> Result<Self, VideoError> {
         if config.codec != Codec::H264 {
             return Err(VideoError::UnsupportedCodec {
-                codec: config.codec,
+                codec: config.codec.to_string(),
             });
         }
 


### PR DESCRIPTION
## Summary
- Host now communicates actual encoder codec to client via existing `HandshakeRequest/Response` after auth, before streaming begins
- Fixes codec mismatch where OpenH264 fallback silently downgrades HEVC→H.264 but client hard-coded HEVC decoder
- Adds `Display`/`FromStr` for `Codec` enum, splits host `stream()` into prepare + stream phases

## Test plan
- [x] fmt ✓, clippy ✓, tests ✓ (247 pass), coverage ✓
- [ ] Manual test: host on macOS with `fallback` feature streams H.264, client negotiates and decodes correctly
- [ ] Manual test: host with `ffmpeg-fallback` streams HEVC, client negotiates and decodes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)