### PR TITLE
fix(video): handle TimedOut errors from scrap capture on Windows (#104)

### DIFF
--- a/crates/rayplay-cli/src/host.rs
+++ b/crates/rayplay-cli/src/host.rs
@@ -184,9 +184,12 @@ pub(crate) fn drive_encode_loop(
     loop {
         let frame = match capturer.capture_frame() {
             Ok(f) => f,
-            Err(CaptureError::Timeout(_)) => {
+            Err(CaptureError::Timeout(d)) => {
                 if packet_tx.is_closed() {
                     return;
+                }
+                if d.is_zero() {
+                    std::thread::sleep(std::time::Duration::from_millis(1));
                 }
                 continue;
             }

--- a/crates/rayplay-video/src/scrap_capture.rs
+++ b/crates/rayplay-video/src/scrap_capture.rs
@@ -61,7 +61,10 @@ impl ScrapCapturer {
 impl ScreenCapturer for ScrapCapturer {
     fn capture_frame(&mut self) -> Result<CapturedFrame, CaptureError> {
         let data = self.source.grab().map_err(|e| {
-            if e.kind() == std::io::ErrorKind::WouldBlock {
+            if matches!(
+                e.kind(),
+                std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+            ) {
                 CaptureError::Timeout(Duration::from_millis(0))
             } else {
                 CaptureError::AcquireFailed(e.to_string())
@@ -149,6 +152,20 @@ mod tests {
     #[test]
     fn test_capture_frame_would_block_maps_to_timeout() {
         let mut capturer = make_failing_capturer();
+        let err = capturer.capture_frame().expect_err("should fail");
+        assert!(matches!(err, CaptureError::Timeout(_)));
+    }
+
+    #[test]
+    fn test_capture_frame_timed_out_maps_to_timeout() {
+        let mut capturer = ScrapCapturer {
+            source: Box::new(MockSource {
+                data: vec![],
+                fail_kind: Some(std::io::ErrorKind::TimedOut),
+            }),
+            width: 100,
+            height: 100,
+        };
         let err = capturer.capture_frame().expect_err("should fail");
         assert!(matches!(err, CaptureError::Timeout(_)));
     }


### PR DESCRIPTION
## Summary
- Fix Windows host errors when using software encoding (--software parameter)
- Map both WouldBlock and TimedOut I/O errors to CaptureError::Timeout  
- Add frame pacing (1ms sleep) when timeout duration is zero to prevent busy-looping
- Add test for TimedOut error mapping

## Root Cause
The `scrap` capture library on Windows can return either `WouldBlock` or `TimedOut` when no frame is available. Previously, only `WouldBlock` was mapped to `CaptureError::Timeout`, causing `TimedOut` errors to be treated as acquisition failures and resulting in busy-looping with 100% CPU usage.

## Changes Made
1. **Error classification fix** (`scrap_capture.rs`): Changed error matching to handle both `WouldBlock` and `TimedOut` as timeout conditions
2. **Frame pacing** (`host.rs`): Added 1ms sleep when timeout duration is zero to prevent busy-looping
3. **Test coverage**: Added unit test for `TimedOut` error mapping

## Test Plan
- [x] Code compiles successfully  
- [x] All existing tests pass
- [x] New test `test_capture_frame_timed_out_maps_to_timeout` passes
- [x] Quality gates pass (fmt, clippy, coverage)

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)